### PR TITLE
port ranges

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: CTF-PHPWebserver
     image: php:8.2-apache
     ports:
-      - "8080:80"
+      - "80-90:80"
     volumes:
       # 1. Mount the entire root of the project to /workspace.
       # When VS Code attaches, it will see the root folder structure.


### PR DESCRIPTION
Implemented port ranges for `PHP-Webserver`.

Instead of binding to port 8080, it is now on the range `80-90`. 
Docker will try to bind your web server to host port 80. If 80 is busy, it moves to 81, and so on to 90.